### PR TITLE
fill out README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,13 @@ credentials['SECRET'] # = > 'secretone'
 ```
 
 Each call to `.fetch_group` would then pull up a new random group of key+secret pairs, where the return value is a hash with the `suffix`es as the keys.
+
+## FAQ
+
+##### Do the numbers have to start at `0`? What if I'm missing a number?
+
+The numbering scheme is really only for grouping values... the numbers themselves are arbitrary, so it doesn't matter in either case.
+
+##### What if I leave out a `suffix` for one of the groups?
+
+That key/value will simply be missing from the returned hash. Tourney **does not** do any validation that all `suffix`es are present for all groups.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tourney
 
-TODO: Write a gem description
+A Ruby gem to cycle (round-robin style) through environment variables. Say you have servers you want to load-balance requests to in a simple way, or have multiple API keys that you need to switch between.
 
 ## Installation
 
@@ -14,18 +14,21 @@ And then execute:
 
     $ bundle
 
-Or install it yourself as:
-
-    $ gem install tourney
-
 ## Usage
 
-TODO: Write usage instructions here
+Let's say we want to cycle between multiple API keys. We would pick a "base name", e.g. `API_HOST`, and set up our environment variables like so:
 
-## Contributing
+```bash
+API_HOST_0=hostzero.foo.com
+API_HOST_1=hostone.foo.com
+API_HOST_2=hosttwo.foo.com
+# ...
+```
 
-1. Fork it ( https://github.com/[my-github-username]/tourney/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+Within our app, we would then use Tourney to retrieve a random `API_HOST_*` for use in that process/request/iteration:
+
+```ruby
+Tourney.fetch('API_HOST') # => 'hosttwo.foo.com'
+Tourney.fetch('API_HOST') # => 'hostzero.foo.com'
+# ...
+```

--- a/README.md
+++ b/README.md
@@ -16,19 +16,52 @@ And then execute:
 
 ## Usage
 
-Let's say we want to cycle between multiple API keys. We would pick a "base name", e.g. `API_HOST`, and set up our environment variables like so:
+### Simple
+
+Let's say we want to cycle between multiple hostnames. We would pick a "base name", e.g. `WORKER_HOST`, and set up our environment variables like so (note these are dummy values):
 
 ```bash
-API_HOST_0=hostzero.foo.com
-API_HOST_1=hostone.foo.com
-API_HOST_2=hosttwo.foo.com
+WORKER_HOST_0=hostzero.foo.com
+WORKER_HOST_1=hostone.foo.com
+WORKER_HOST_2=hosttwo.foo.com
 # ...
 ```
 
-Within our app, we would then use Tourney to retrieve a random `API_HOST_*` for use in that process/request/iteration:
+The environment variables are of the format `<base>_<n>`.
+
+#### `Tourney.fetch(base)`
+
+Within our app, we would then use Tourney to retrieve a random `WORKER_HOST_*` for use in that process/request/iteration:
 
 ```ruby
-Tourney.fetch('API_HOST') # => 'hosttwo.foo.com'
-Tourney.fetch('API_HOST') # => 'hostzero.foo.com'
+Tourney.fetch('WORKER_HOST') # => 'hosttwo.foo.com'
+Tourney.fetch('WORKER_HOST') # => 'hostzero.foo.com'
 # ...
 ```
+
+### Grouped
+
+Some environments come in sets, e.g. API keys+secrets. For these, set up your environment variables like so:
+
+```bash
+SOME_API_KEY_0=keyzero
+SOME_API_SECRET_0=secretzero
+SOME_API_KEY_1=keyone
+SOME_API_SECRET_1=secretone
+# ...
+```
+
+where the variable names are of the format `<base>_<suffix>_<n>`. Note there can be any number of `base`s, `suffix`es, and groups (`n >= 0`).
+
+#### `Tourney.fetch_group(base)`
+
+You then call `.fetch_group` with the `base`:
+
+```ruby
+credentials = Tourney.fetch_group('SOME_API')
+credentials # => {'KEY' => 'keyone', 'SECRET' => 'secretone'}
+credentials['KEY'] # => 'keyone'
+credentials['SECRET'] # = > 'secretone'
+```
+
+Each call to `.fetch_group` would then pull up a new random group of key+secret pairs, where the return value is a hash with the `suffix`es as the keys.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ WORKER_HOST_2=hosttwo.foo.com
 # ...
 ```
 
-The environment variables are of the format `<base>_<n>`.
+The environment variables are of the format `<base>_<n>`, where `n >= 0`.
 
 #### `Tourney.fetch(base)`
 
@@ -38,6 +38,8 @@ Tourney.fetch('WORKER_HOST') # => 'hosttwo.foo.com'
 Tourney.fetch('WORKER_HOST') # => 'hostzero.foo.com'
 # ...
 ```
+
+Note that you don't have to specify how many `WORKER_HOST`s are available from your code – Tourney will figure it out!
 
 ### Grouped
 
@@ -51,7 +53,7 @@ SOME_API_SECRET_1=secretone
 # ...
 ```
 
-where the variable names are of the format `<base>_<suffix>_<n>`. Note there can be any number of `base`s, `suffix`es, and groups (`n >= 0`).
+where the variable names are of the format `<base>_<suffix>_<n>`. Note there can be any number of `base`s, `suffix`es, and groups.
 
 #### `Tourney.fetch_group(base)`
 


### PR DESCRIPTION
I'm going with README-Driven Development for this gem :scroll: :paperclip: :memo: :zap: 

Some background: @jgrevich, @amoose and I are trying to use SMS for one-time passwords, but it seems that carriers impose a rate limit of one outbound message per second for long codes (ten-digit numbers). Our plan is round-robin between a handful of phone numbers, so this gem will allow us to easily access the numbers+keys+secrets from environment variables for however many we need on that particular host.

Outside of our particular case, does this gem seem like it would be useful? Another solution I've seen is shoving an encoded JSON/YAML object into a single environment variable, but that's always felt a bit messy to me. Granted, this creates a lot more clutter in terms of the _number_ of environment variables, but at least they are easier to read/change. Thoughts?
