### PR TITLE
include group number in hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You then call `.fetch_group` with the `base`:
 
 ```ruby
 credentials = Tourney.fetch_group('SOME_API')
-credentials # => {'KEY' => 'keyone', 'SECRET' => 'secretone'}
+credentials # => {'_n' => 1, 'KEY' => 'keyone', 'SECRET' => 'secretone'}
 credentials['KEY'] # => 'keyone'
 credentials['SECRET'] # = > 'secretone'
 ```


### PR DESCRIPTION
Thinking it might be useful for debugging to know which group the config values came from... not sure the best way to include the variable number for the singular case, since it only returns a string.
